### PR TITLE
Add fanout balance to claim

### DIFF
--- a/hooks/useFanoutData.ts
+++ b/hooks/useFanoutData.ts
@@ -25,8 +25,11 @@ export const useFanoutData = () => {
       if (!fanoutId) return
       const [nativeAccount] = await FanoutClient.nativeAccount(fanoutId)
       const fanout = await fanoutSdk.fetch<Fanout>(fanoutId, Fanout)
-      const balance =
-        (await connection.getBalance(nativeAccount)) / LAMPORTS_PER_SOL
+      const [fanoutBalance, nativeBalance] = await Promise.all([
+        connection.getBalance(fanoutId),
+        connection.getBalance(nativeAccount),
+      ])
+      const balance = (fanoutBalance + nativeBalance) / LAMPORTS_PER_SOL
       return { fanoutId, fanout, nativeAccount, balance }
     },
     [fanoutId?.toString()],


### PR DESCRIPTION
Hydra latest launch allows the ability to collect SOL balance stuck in the fanout wallet. This PR will show this balance.

It also fixes the issue from Phantom returning the signed transaction when using the `signTransaction` method, instead of updating the one passed in.